### PR TITLE
Add filter for the transient's name in Eventbrite Manager.

### DIFF
--- a/inc/class-eventbrite-manager.php
+++ b/inc/class-eventbrite-manager.php
@@ -237,7 +237,9 @@ class Eventbrite_Manager {
 	 */
 	protected function get_transient_name( $endpoint, $params ) {
 		// Results in 62 characters for the timeout option name (maximum is 64).
-		return 'eventbrite_' . md5( $endpoint . implode( $params ) );
+		$transient_name = 'eventbrite_' . md5( $endpoint . implode( $params ) );
+
+		return apply_filters( 'eventbrite_transient_name', $transient_name, $endpoint, $params );
 	}
 
 	/**


### PR DESCRIPTION
Hi everyone,

Thank you for this great plugin. It definitely saved me a lot of time last week!

Recently, I had to use Eventbrite API in a server that runs a 32-bit build of PHP. [As you know](https://github.com/Automattic/eventbrite-api/issues/32), the events IDs from Eventbrite cannot be represented as a 32-bit integers, causing problems with most of the plugin's features.

I was able to get most of the features I need working, using filters and actions to insert the original ID in the necessary places. The details are [here](http://wvega.com/850/getting-eventbrite-api-wordpress-plugin-to-work-on-systems-with-32-bit-builds-of-php/). My approach does not solve all the problems, but was almost enough for us.

Unfortunately, there is one more problem that I don't think I can solve using existing hooks. When the Event Manager creates the transient name to cache the results of a request to the `event_details` endpoint, the value stored in the `p` index of the parameters array is set to `2147483647` no matter which event is being queried.

In my website, the requests ultimately returns the desired information, because I update the endpoint's URL to include the real ID, but Event Manager is not aware of that modification and as a result all my single event pages are showing information for the same event: the cached version of whichever event was requested first.

The commit in this PR adds a filter in the `get_transient_name` method of Event Manager class, that will allow me to generate a transient name using the real event ID, preventing the problem I just explained.

Is it possible to add that filter to the plugin?

I've been trying to solve the issues I found without touching the plugin's code, and that filter is, I think, the last piece of the puzzle. If you merge this PR, I can update my copy of Eventbrite API with the same modifications, knowing the next version will officially introduce the filter, thus making sure my solution will continue to be compatible.

Thank you!