### PR TITLE
Add a filter for which expansions should be included in API responses.

### DIFF
--- a/inc/class-eventbrite-api.php
+++ b/inc/class-eventbrite-api.php
@@ -85,7 +85,7 @@ class Eventbrite_API extends Keyring_Service_Eventbrite {
 			return new Keyring_Error( '400', 'No token present for the Eventbrite API.' );
 
 		$endpoint_url = self::$instance->{$endpoint . '_url'};
-		$query_params['expand'] = 'logo,organizer,venue,ticket_classes,format,category,subcategory';
+		$query_params['expand'] = apply_filters( 'eventbrite_api_expansions', 'logo,organizer,venue,ticket_classes,format,category,subcategory', $endpoint, $query_params, $object_id );
 		$method = self::$instance->{$endpoint . '_method'};
 		$params = array( 'method' => $method );
 


### PR DESCRIPTION
This filter will allow devs to adjust the [expansions](https://www.eventbrite.com/developer/v3/reference/expansions/) requested on all API calls. Of note would be the ability to remove `ticket_classes`, which Eventbrite has indicated can result in expensive calls, and is only used in the Eventbrite API plugin for calculating the `iframe` height of ticket details.