### PR TITLE
Allow sort_by to be set when searching for events

### DIFF
--- a/inc/class-eventbrite-query.php
+++ b/inc/class-eventbrite-query.php
@@ -153,7 +153,11 @@ class Eventbrite_Query extends WP_Query {
 		// We need the Eventbrite user ID (or an organizer) if we're getting only public events.
 		if ( ! isset( $this->query_vars['display_private'] ) || true !== $this->query_vars['display_private'] ) {
 			// Set sorting.
-			$params['sort_by'] = 'date';
+			if ( ! empty( $this->query_vars['sort_by'] ) ) {
+				$params['sort_by'] = $this->query_vars['sort_by'];
+			} else {
+				$params['sort_by'] = 'date';
+			}
 
 			// Set the user ID if we don't have a specified organizer.
 			if ( ! empty( $this->query_vars['organizer_id'] ) ) {


### PR DESCRIPTION
Hello and thanks for the plugin!

I was working on adding an event search integration and noticed that the plugin currently doesn't allow `sort_by` to be set when making requests against the `/events/search/`endpoint, it just defaults to `date`. 

It also seems that the allowed sorting options don't match up to what is now available (which is something that probably changed with Eventbrite's 3rd version of the API — https://www.eventbrite.com.au/developer/v3/endpoints/events/#ebapi-get-events-search)

I've opened up a PR as a suggestion of how I'd see this working, but since the allowed sorting options don't quite match, those might need to be updated too.

Anyway, thanks again for the work on this plugin, it's much appreciated.