### PR TITLE
Enabling force flag

### DIFF
--- a/inc/class-eventbrite-query.php
+++ b/inc/class-eventbrite-query.php
@@ -97,6 +97,8 @@ class Eventbrite_Query extends WP_Query {
 	public function get_posts() {
 		// Set up query variables.
 		$this->parse_query();
+		// force flag
+		$force = ( isset( $this->query_vars['force'] ) ) ? $this->query_vars['force'] : false;
 
 		// Restore `paged` if changed to `page` (in the case of index pagination).
 		if ( ! empty( $this->query_vars['page'] ) ) {
@@ -109,17 +111,17 @@ class Eventbrite_Query extends WP_Query {
 
 		// Determine which endpoint is needed. Do we want just a single event?
 		if ( ! empty( $this->query_vars['p'] ) ) {
-			$this->api_results = eventbrite()->get_event( $this->query_vars['p'] );
+			$this->api_results = eventbrite()->get_event( $this->query_vars['p'], $force );
 		}
 
 		// If private events are wanted, the user_owned_events endpoint must be used.
 		elseif ( isset( $this->query_vars['display_private'] ) && true === $this->query_vars['display_private'] ) {
-			$this->api_results = eventbrite()->get_user_owned_events( $params );
+			$this->api_results = eventbrite()->get_user_owned_events( $params, $force );
 		}
 
 		// It's a run-of-the-mill query (only the user's public live events), meaning event_search is best.
 		else {
-			$this->api_results = eventbrite()->do_event_search( $params );
+			$this->api_results = eventbrite()->do_event_search( $params, $force );
 		}
 
 		// Do any post-API query processing.


### PR DESCRIPTION
I've come across the issue of updating the Eventbrite data on a Wordpress site. 

There have been threads online suggesting that the _best_ way would be to reset the keyring auth. 

Looking through the code, there has already been providence on the matter as the query methods support a "force" parameter. This parameter is not defined though when querying the data. 

This tweak adds support for a "force" option during initialization that then is broadcast to the query methods.